### PR TITLE
Changed rm functions parameter name

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,8 +56,8 @@ class EventRegister {
     return EventRegister.addEventListener(eventName, callback)
   }
 
-  static rm(eventName) {
-    return EventRegister.removeEventListener(eventName)
+  static rm(eventId) {
+    return EventRegister.removeEventListener(eventId)
   }
 
   static rmAll() {


### PR DESCRIPTION
it was confusing because i can emit the event with its name but in order to remove it my intelliSense tells me that i can remove it with its name but actually i should remove the event with its returned id.